### PR TITLE
Enable demo mode fallback when Supabase credentials are missing

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,11 +3,15 @@ import { Session } from '@supabase/supabase-js';
 import { supabase } from '../lib/supabase';
 
 interface HeaderProps {
-    session: Session;
+    session: Session | null;
+    isDemoMode?: boolean;
 }
 
-const Header: React.FC<HeaderProps> = ({ session }) => {
+const Header: React.FC<HeaderProps> = ({ session, isDemoMode = false }) => {
   const handleSignOut = async () => {
+    if (!session) {
+      return;
+    }
     await supabase.auth.signOut();
   }
 
@@ -20,15 +24,23 @@ const Header: React.FC<HeaderProps> = ({ session }) => {
           </h1>
         </div>
         <div className="flex items-center space-x-4">
+          {isDemoMode || !session ? (
             <div className="text-sm text-gray-600">
-                Signed in as <span className="font-medium text-navy-800">{session.user.email}</span>
+              Viewing <span className="font-medium text-navy-800">demo data</span>
             </div>
-            <button
+          ) : (
+            <>
+              <div className="text-sm text-gray-600">
+                Signed in as <span className="font-medium text-navy-800">{session.user.email}</span>
+              </div>
+              <button
                 onClick={handleSignOut}
                 className="inline-flex justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-usace-red focus:ring-offset-2"
-            >
+              >
                 Sign Out
-            </button>
+              </button>
+            </>
+          )}
         </div>
       </div>
     </header>

--- a/constants.ts
+++ b/constants.ts
@@ -1,9 +1,71 @@
 import { KpiDataPoint, EntryType, NavItem, Campaign } from './types';
 import { HomeIcon, TableCellsIcon, DocumentPlusIcon, ClipboardDocumentListIcon, MegaphoneIcon } from './components/Icons';
 
-export const MOCK_CAMPAIGN_DATA: Campaign[] = [];
+export const MOCK_CAMPAIGN_DATA: Campaign[] = [
+  {
+    id: 1,
+    name: 'Snake River Navigation Safety',
+    description: 'Seasonal outreach encouraging safe recreation along the Lower Snake River.',
+    startDate: '2024-05-01',
+    endDate: '2024-09-30',
+  },
+  {
+    id: 2,
+    name: 'Mill Creek Flood Risk Awareness',
+    description: 'Community education campaign focused on spring flood preparedness.',
+    startDate: '2024-02-15',
+    endDate: '2024-04-30',
+  },
+];
 
-export const MOCK_KPI_DATA: KpiDataPoint[] = [];
+export const MOCK_KPI_DATA: KpiDataPoint[] = [
+  {
+    id: 101,
+    date: '2024-09-10',
+    type: EntryType.OUTTAKE,
+    metric: 'Media pickups',
+    quantity: 14,
+    notes: 'Regional outlets covered the new lock operations schedule.',
+    campaignId: 1,
+  },
+  {
+    id: 102,
+    date: '2024-09-05',
+    type: EntryType.OUTPUT,
+    metric: 'News release',
+    quantity: 3,
+    notes: 'Safety reminder releases distributed to local media partners.',
+    campaignId: 1,
+    link: 'https://example.com/releases/snake-river-safety',
+  },
+  {
+    id: 103,
+    date: '2024-08-28',
+    type: EntryType.OUTTAKE,
+    metric: 'Engagement rate',
+    quantity: 4.8,
+    notes: 'Average engagement across campaign social content.',
+    campaignId: 1,
+  },
+  {
+    id: 104,
+    date: '2024-03-18',
+    type: EntryType.OUTCOME,
+    metric: 'Awareness lift',
+    quantity: 18,
+    notes: 'Post-event survey showed increased awareness of flood risks.',
+    campaignId: 2,
+  },
+  {
+    id: 105,
+    date: '2024-03-12',
+    type: EntryType.OUTTAKE,
+    metric: 'Video views',
+    quantity: 1260,
+    notes: 'Preparedness PSA performance on social channels.',
+    campaignId: 2,
+  },
+];
 
 
 export const NAVIGATION_ITEMS: NavItem[] = [


### PR DESCRIPTION
## Summary
- add a demo-mode fallback path in the app that seeds mock KPI/campaign data and normalizes Supabase responses
- seed realistic mock data to drive the dashboard when authentication is disabled
- update the header to support demo mode messaging while keeping sign-out for authenticated sessions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1f1064e608328acb625883c2171b0